### PR TITLE
feat(trace): OpenTelemetry-friendly correlation across all logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ behavior (including NestJS 11's structured-JSON output) and adds a clean
 - 🧩 **Exporters as adapters** — send the same log stream to many destinations.
 - 🪶 **Zero-bloat core** — heavy SDKs (`pg`, `mongodb`, `aws-sdk`) are
   **optional peer dependencies**, loaded on demand only when used.
-- 🧵 **Correlation IDs** — automatic per-request tracing via `AsyncLocalStorage`.
+- 🧵 **Correlation & tracing** — a `trace_id`/`span_id` traverses every log via
+  `AsyncLocalStorage`; **OpenTelemetry-friendly** and pluggable (W3C `traceparent`
+  by default, active OTel span when the SDK is present) + an OTLP log exporter.
 - 🔒 **Redaction** — strip secrets (`password`, `authorization`, …) before export.
 - 🛡️ **Failure isolation** — a broken exporter never crashes your app or the others.
 - 🎯 **Auto-context** — the logger derives its context from the injecting class,
@@ -34,7 +36,8 @@ npm install pg                                   # PgExporter
 npm install mongodb                              # MongoExporter
 npm install @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb   # DynamoDBExporter
 npm install @aws-sdk/client-cloudwatch-logs      # CloudWatchExporter
-# FileExporter, HttpExporter and ConsoleExporter have no extra dependencies.
+npm install @opentelemetry/api                   # OtelTraceContextProvider
+# File, Http, Console and OTLP exporters have no extra dependencies.
 ```
 
 ## Quickstart
@@ -100,11 +103,11 @@ export class BillingService {
 
 > `forFeature` requires `LoggerModule.forRoot({ isGlobal: true })` to be registered.
 
-## Correlation IDs
+## Correlation & OpenTelemetry tracing
 
 Register the middleware to open a per-request async context. Every log emitted
-during the request is automatically stamped with the correlation id, and the id
-is echoed back on the `x-correlation-id` response header.
+during the request is automatically stamped with a **`trace_id`**, **`span_id`**
+and **`correlationId`** — so a single id traverses *all* logs of a request.
 
 ```ts
 import { CorrelationMiddleware, setContext } from '@mpgxc/logx';
@@ -118,6 +121,45 @@ export class AppModule implements NestModule {
 
 // Enrich the active request context anywhere downstream:
 setContext({ userId, tenant });
+```
+
+The middleware honors the **W3C `traceparent`** header when present (so ids
+propagated from an upstream service flow through), and generates fresh ids
+otherwise. It echoes `x-correlation-id` back on the response.
+
+Every record carries the trace fields in **snake_case** (`trace_id`, `span_id`,
+`trace_flags`) — the OpenTelemetry/ECS log convention — so **Grafana Loki,
+Datadog and Elastic auto-correlate logs with traces** without extra config.
+
+### Pluggable trace source
+
+The trace context is produced by a `TraceContextProvider`. The default is
+zero-dependency (reads the async store above). To pick up the **active
+OpenTelemetry span** when you run an OTel SDK, swap in the OTel provider:
+
+```ts
+import { LoggerModule, OtelTraceContextProvider } from '@mpgxc/logx';
+
+LoggerModule.forRoot({
+  isGlobal: true,
+  traceContext: new OtelTraceContextProvider(), // needs @opentelemetry/api
+});
+```
+
+Now logs are stamped with the real `trace_id`/`span_id` of the current span,
+falling back to the middleware-generated ids when no span is active. Implement
+`TraceContextProvider` yourself to bridge any other tracing system.
+
+### Ship logs to an OpenTelemetry Collector
+
+`OtlpExporter` sends logs over **OTLP/HTTP (JSON)** — no OTel SDK required
+(Collectors accept OTLP/JSON on `/v1/logs`). Trace ids map to the OTLP record's
+`traceId`/`spanId`, closing the loop:
+
+```ts
+import { OtlpExporter } from '@mpgxc/logx';
+
+new OtlpExporter({ endpoint: 'http://collector:4318', serviceName: 'api' });
 ```
 
 ## Async configuration
@@ -145,6 +187,7 @@ LoggerModule.forRootAsync({
 | `MongoExporter`      | MongoDB collection                   | `mongodb` |
 | `DynamoDBExporter`   | DynamoDB table                       | `@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb` |
 | `CloudWatchExporter` | AWS CloudWatch Logs                  | `@aws-sdk/client-cloudwatch-logs` |
+| `OtlpExporter`       | OpenTelemetry Collector (OTLP/HTTP)  | — (uses global `fetch`) |
 
 ```ts
 new HttpExporter({ url, format: 'loki', labels: { app: 'api' } });
@@ -187,6 +230,7 @@ LoggerModule.forRoot({
   redact?: string[];    // keys stripped from meta          (default: [])
   exporters?: LogExporter[];                                 // default: []
   batch?: { size?: number; intervalMs?: number };            // default: 100 / 2000ms
+  traceContext?: TraceContextProvider;                       // default: ALS (zero-dep)
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0",
+        "@opentelemetry/api": "^1.9.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^12.0.0",
         "@semantic-release/git": "^10.0.1",
@@ -39,6 +40,7 @@
         "@aws-sdk/lib-dynamodb": "^3.0.0",
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0",
+        "@opentelemetry/api": "^1.9.0",
         "mongodb": "^6.0.0",
         "pg": "^8.0.0"
       },
@@ -50,6 +52,9 @@
           "optional": true
         },
         "@aws-sdk/lib-dynamodb": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
           "optional": true
         },
         "mongodb": {
@@ -1381,6 +1386,16 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^22.1.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/lib-dynamodb": "^3.0.0",
@@ -64,6 +65,9 @@
     "pg": "^8.0.0"
   },
   "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    },
     "@aws-sdk/client-cloudwatch-logs": {
       "optional": true
     },
@@ -83,6 +87,7 @@
   "devDependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^12.0.0",
     "@semantic-release/git": "^10.0.1",

--- a/src/context/als.ts
+++ b/src/context/als.ts
@@ -7,6 +7,12 @@ import { AsyncLocalStorage } from 'node:async_hooks';
  */
 export interface LogStore {
   correlationId?: string;
+  /** W3C/OpenTelemetry trace id (32-char hex). */
+  traceId?: string;
+  /** OpenTelemetry span id (16-char hex). */
+  spanId?: string;
+  /** OpenTelemetry trace flags (2-char hex). */
+  traceFlags?: string;
   [key: string]: unknown;
 }
 

--- a/src/context/correlation.middleware.spec.ts
+++ b/src/context/correlation.middleware.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CorrelationMiddleware,
+  TracingMiddleware,
+} from './correlation.middleware';
+import { getStore, type LogStore } from './als';
+
+const run = (headers: Record<string, string> = {}) => {
+  const mw = new CorrelationMiddleware();
+  const res = { setHeader: vi.fn() };
+  let store: LogStore | undefined;
+  mw.use({ headers }, res, () => {
+    store = getStore();
+  });
+  return { store: store!, res };
+};
+
+describe('CorrelationMiddleware', () => {
+  it('reuses an incoming W3C traceparent', () => {
+    const traceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+    const spanId = '00f067aa0ba902b7';
+    const { store } = run({ traceparent: `00-${traceId}-${spanId}-01` });
+
+    expect(store.traceId).toBe(traceId);
+    expect(store.spanId).toBe(spanId);
+    expect(store.traceFlags).toBe('01');
+  });
+
+  it('generates a trace id when no traceparent is present', () => {
+    const { store } = run();
+
+    expect(store.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(store.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(store.correlationId).toBeTruthy();
+  });
+
+  it('reuses and echoes x-correlation-id', () => {
+    const { store, res } = run({ 'x-correlation-id': 'abc-123' });
+
+    expect(store.correlationId).toBe('abc-123');
+    expect(res.setHeader).toHaveBeenCalledWith('x-correlation-id', 'abc-123');
+  });
+
+  it('exposes a TracingMiddleware alias', () => {
+    expect(TracingMiddleware).toBe(CorrelationMiddleware);
+  });
+});

--- a/src/context/correlation.middleware.ts
+++ b/src/context/correlation.middleware.ts
@@ -1,6 +1,11 @@
 import { Injectable, type NestMiddleware } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import { CORRELATION_ID_HEADER } from '../logger.constants';
+import { CORRELATION_ID_HEADER, TRACEPARENT_HEADER } from '../logger.constants';
+import {
+  generateSpanId,
+  generateTraceId,
+  parseTraceparent,
+} from '../logger.utils';
 import { runWithStore } from './als';
 
 type ReqLike = {
@@ -10,11 +15,17 @@ type ResLike = {
   setHeader: (name: string, value: string) => void;
 };
 
+const header = (value: string | string[] | undefined): string | undefined =>
+  Array.isArray(value) ? value[0] : value;
+
 /**
- * Opens a per-request async store carrying a correlation id. If the
- * incoming request already has an `x-correlation-id` header it is reused;
- * otherwise a fresh UUID is generated. The id is echoed back on the
- * response and attached to every log emitted during the request.
+ * Opens a per-request async store carrying trace correlation.
+ *
+ * - Honors the W3C `traceparent` header when present, so a `trace_id` /
+ *   `span_id` propagated from an upstream service flows through every log.
+ * - When absent, generates a fresh `trace_id`/`span_id` — guaranteeing that a
+ *   trace id traverses **all** logs of the request even without any tracing SDK.
+ * - Reuses/echoes `x-correlation-id` for human-friendly correlation.
  *
  * Register it in your `AppModule`:
  * ```ts
@@ -28,12 +39,20 @@ type ResLike = {
 @Injectable()
 export class CorrelationMiddleware implements NestMiddleware {
   use(req: ReqLike, res: ResLike, next: () => void): void {
-    const incoming = req.headers[CORRELATION_ID_HEADER];
+    const parent = parseTraceparent(header(req.headers[TRACEPARENT_HEADER]));
+
+    const traceId = parent?.traceId ?? generateTraceId();
+    const spanId = parent?.spanId ?? generateSpanId();
+    const traceFlags = parent?.traceFlags ?? '01';
+
     const correlationId =
-      (Array.isArray(incoming) ? incoming[0] : incoming) || randomUUID();
+      header(req.headers[CORRELATION_ID_HEADER]) || randomUUID();
 
     res.setHeader(CORRELATION_ID_HEADER, correlationId);
 
-    runWithStore({ correlationId }, () => next());
+    runWithStore({ correlationId, traceId, spanId, traceFlags }, () => next());
   }
 }
+
+/** Alias — the middleware also establishes tracing, not just correlation. */
+export { CorrelationMiddleware as TracingMiddleware };

--- a/src/context/otel-trace-context.ts
+++ b/src/context/otel-trace-context.ts
@@ -1,0 +1,50 @@
+import type { TraceContext, TraceContextProvider } from '../logger.interfaces';
+import { getStore } from './als';
+import { defaultTraceContextProvider } from './trace-context';
+import { loadOptional } from '../exporters/optional-dep';
+
+const INVALID_TRACE_ID = '00000000000000000000000000000000';
+
+/**
+ * Trace-context provider that reads the **active OpenTelemetry span**. When an
+ * OTel SDK is running, every log is automatically stamped with the real
+ * `trace_id`/`span_id` of the current span, so logs correlate with traces in
+ * the same backend.
+ *
+ * Requires the optional peer dependency `@opentelemetry/api`. When no span is
+ * active it falls back to the async store (W3C `traceparent` / ids generated
+ * by {@link CorrelationMiddleware}), so a trace id still traverses every log.
+ */
+export class OtelTraceContextProvider implements TraceContextProvider {
+  readonly name = 'opentelemetry';
+  private api: any;
+
+  async init(): Promise<void> {
+    this.api = await loadOptional<any>(
+      '@opentelemetry/api',
+      'OtelTraceContextProvider',
+    );
+  }
+
+  getContext(): TraceContext | undefined {
+    const span = this.api?.trace?.getActiveSpan?.();
+    const spanContext = span?.spanContext?.();
+
+    if (!spanContext || spanContext.traceId === INVALID_TRACE_ID) {
+      // No active span — fall back to the ALS store (correlation id + any
+      // W3C/generated trace ids from the middleware).
+      return defaultTraceContextProvider.getContext();
+    }
+
+    return {
+      traceId: spanContext.traceId,
+      spanId: spanContext.spanId,
+      // OTel exposes traceFlags as a number; the log data model wants 2-hex.
+      traceFlags:
+        typeof spanContext.traceFlags === 'number'
+          ? spanContext.traceFlags.toString(16).padStart(2, '0')
+          : undefined,
+      correlationId: getStore()?.correlationId,
+    };
+  }
+}

--- a/src/context/trace-context.spec.ts
+++ b/src/context/trace-context.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { runWithStore } from './als';
+import {
+  AlsTraceContextProvider,
+  defaultTraceContextProvider,
+} from './trace-context';
+import {
+  generateSpanId,
+  generateTraceId,
+  parseTraceparent,
+} from '../logger.utils';
+
+describe('trace id generation', () => {
+  it('generates 32-hex trace ids and 16-hex span ids', () => {
+    expect(generateTraceId()).toMatch(/^[0-9a-f]{32}$/);
+    expect(generateSpanId()).toMatch(/^[0-9a-f]{16}$/);
+    expect(generateTraceId()).not.toBe(generateTraceId());
+  });
+});
+
+describe('parseTraceparent', () => {
+  const traceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+  const spanId = '00f067aa0ba902b7';
+
+  it('parses a valid W3C traceparent', () => {
+    expect(parseTraceparent(`00-${traceId}-${spanId}-01`)).toEqual({
+      traceId,
+      spanId,
+      traceFlags: '01',
+    });
+  });
+
+  it('rejects malformed or all-zero values', () => {
+    expect(parseTraceparent(undefined)).toBeUndefined();
+    expect(parseTraceparent('garbage')).toBeUndefined();
+    expect(
+      parseTraceparent(`00-${'0'.repeat(32)}-${spanId}-01`),
+    ).toBeUndefined();
+  });
+});
+
+describe('AlsTraceContextProvider', () => {
+  const provider = new AlsTraceContextProvider();
+
+  it('reads trace fields from the active store', () => {
+    runWithStore(
+      { traceId: 'a'.repeat(32), spanId: 'b'.repeat(16), correlationId: 'c1' },
+      () => {
+        expect(provider.getContext()).toEqual({
+          traceId: 'a'.repeat(32),
+          spanId: 'b'.repeat(16),
+          traceFlags: undefined,
+          correlationId: 'c1',
+        });
+      },
+    );
+  });
+
+  it('returns undefined outside any store', () => {
+    expect(provider.getContext()).toBeUndefined();
+    expect(defaultTraceContextProvider.name).toBe('als');
+  });
+});

--- a/src/context/trace-context.ts
+++ b/src/context/trace-context.ts
@@ -1,0 +1,31 @@
+import type { TraceContext, TraceContextProvider } from '../logger.interfaces';
+import { getStore } from './als';
+
+/**
+ * Default, zero-dependency trace-context provider. Reads the trace ids and
+ * correlation id from the `AsyncLocalStorage` store populated by
+ * {@link CorrelationMiddleware} (which honors the W3C `traceparent` header).
+ *
+ * This keeps a `trace_id` flowing through every log of a request even when
+ * no OpenTelemetry SDK is installed.
+ */
+export class AlsTraceContextProvider implements TraceContextProvider {
+  readonly name = 'als';
+
+  getContext(): TraceContext | undefined {
+    const store = getStore();
+    if (!store) {
+      return undefined;
+    }
+
+    return {
+      traceId: store.traceId,
+      spanId: store.spanId,
+      traceFlags: store.traceFlags,
+      correlationId: store.correlationId,
+    };
+  }
+}
+
+/** Shared default provider instance. */
+export const defaultTraceContextProvider = new AlsTraceContextProvider();

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -5,3 +5,4 @@ export * from './pg.exporter';
 export * from './mongo.exporter';
 export * from './dynamodb.exporter';
 export * from './cloudwatch.exporter';
+export * from './otlp.exporter';

--- a/src/exporters/otlp.exporter.spec.ts
+++ b/src/exporters/otlp.exporter.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OtlpExporter } from './otlp.exporter';
+import type { LogRecord } from '../logger.interfaces';
+
+const rec = (over: Partial<LogRecord> = {}): LogRecord => ({
+  level: 'log',
+  message: 'hello',
+  context: 'Api',
+  timestamp: 1700000000000,
+  pid: 1,
+  ...over,
+});
+
+describe('OtlpExporter', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const stubFetch = () => {
+    const fetchMock = vi.fn(
+      async (_url: string, _init: RequestInit) =>
+        ({ ok: true, status: 200, statusText: 'OK' }) as Response,
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  it('posts an OTLP/JSON payload to /v1/logs by default', async () => {
+    const fetchMock = stubFetch();
+    const exporter = new OtlpExporter({ serviceName: 'demo' });
+
+    await exporter.export([rec({ level: 'error', message: 'boom' })]);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://localhost:4318/v1/logs');
+
+    const body = JSON.parse(init.body as string);
+    const resource = body.resourceLogs[0];
+    expect(resource.resource.attributes).toContainEqual({
+      key: 'service.name',
+      value: { stringValue: 'demo' },
+    });
+
+    const otlp = resource.scopeLogs[0].logRecords[0];
+    expect(otlp.severityNumber).toBe(17); // error → ERROR
+    expect(otlp.severityText).toBe('error');
+    expect(otlp.body).toEqual({ stringValue: 'boom' });
+    // nanoseconds = ms * 1e6, as a string
+    expect(otlp.timeUnixNano).toBe('1700000000000000000');
+  });
+
+  it('maps trace_id/span_id onto the OTLP record for correlation', async () => {
+    const fetchMock = stubFetch();
+    const exporter = new OtlpExporter();
+
+    await exporter.export([
+      rec({ trace_id: 'a'.repeat(32), span_id: 'b'.repeat(16) }),
+    ]);
+
+    const otlp = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+      .resourceLogs[0].scopeLogs[0].logRecords[0];
+    expect(otlp.traceId).toBe('a'.repeat(32));
+    expect(otlp.spanId).toBe('b'.repeat(16));
+  });
+
+  it('flattens meta into typed OTLP attributes', async () => {
+    const fetchMock = stubFetch();
+    const exporter = new OtlpExporter();
+
+    await exporter.export([rec({ meta: { userId: 42, active: true } })]);
+
+    const attrs = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+      .resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+    expect(attrs).toContainEqual({ key: 'userId', value: { intValue: 42 } });
+    expect(attrs).toContainEqual({ key: 'active', value: { boolValue: true } });
+  });
+
+  it('throws on a non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        statusText: 'Unavailable',
+      })),
+    );
+    await expect(new OtlpExporter().export([rec()])).rejects.toThrow(
+      'OTLP 503',
+    );
+  });
+});

--- a/src/exporters/otlp.exporter.ts
+++ b/src/exporters/otlp.exporter.ts
@@ -1,0 +1,129 @@
+import { OTEL_SEVERITY_NUMBER } from '../logger.constants';
+import type { LogExporter, LogRecord } from '../logger.interfaces';
+
+export interface OtlpExporterOptions {
+  /** Collector base URL. Default: `http://localhost:4318`. */
+  endpoint?: string;
+  /** Logs path appended to the endpoint. Default: `/v1/logs`. */
+  path?: string;
+  /** `service.name` resource attribute. Default: `nestjs`. */
+  serviceName?: string;
+  /** Extra headers (auth, tenant, …). */
+  headers?: Record<string, string>;
+  /** Per-request timeout in ms. Default: 5000. */
+  timeoutMs?: number;
+}
+
+type AnyValue =
+  | { stringValue: string }
+  | { intValue: number }
+  | { doubleValue: number }
+  | { boolValue: boolean };
+
+const toAnyValue = (value: unknown): AnyValue => {
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (typeof value === 'number') {
+    return Number.isInteger(value)
+      ? { intValue: value }
+      : { doubleValue: value };
+  }
+  if (typeof value === 'string') return { stringValue: value };
+  return { stringValue: JSON.stringify(value) };
+};
+
+const attr = (key: string, value: unknown) => ({
+  key,
+  value: toAnyValue(value),
+});
+
+/**
+ * Ships records to an OpenTelemetry Collector via **OTLP/HTTP (JSON)**. Uses
+ * the global `fetch`, so it needs no OpenTelemetry SDK — Collectors accept
+ * OTLP/JSON on `/v1/logs` (port 4318 by default).
+ *
+ * Trace correlation is preserved: `trace_id`/`span_id` map to the OTLP log
+ * record's `traceId`/`spanId`, letting the backend join logs to traces.
+ */
+export class OtlpExporter implements LogExporter {
+  readonly name = 'otlp';
+
+  private readonly url: string;
+  private readonly serviceName: string;
+  private readonly headers: Record<string, string>;
+  private readonly timeoutMs: number;
+
+  constructor(options: OtlpExporterOptions = {}) {
+    const endpoint = (options.endpoint ?? 'http://localhost:4318').replace(
+      /\/$/,
+      '',
+    );
+    this.url = `${endpoint}${options.path ?? '/v1/logs'}`;
+    this.serviceName = options.serviceName ?? 'nestjs';
+    this.headers = options.headers ?? {};
+    this.timeoutMs = options.timeoutMs ?? 5000;
+  }
+
+  async export(records: LogRecord[]): Promise<void> {
+    if (!records.length) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(this.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...this.headers },
+        body: JSON.stringify(this.toPayload(records)),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`OTLP ${response.status} ${response.statusText}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private toPayload(records: LogRecord[]) {
+    return {
+      resourceLogs: [
+        {
+          resource: {
+            attributes: [attr('service.name', this.serviceName)],
+          },
+          scopeLogs: [
+            {
+              scope: { name: '@mpgxc/logx' },
+              logRecords: records.map((r) => this.toLogRecord(r)),
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  private toLogRecord(r: LogRecord) {
+    const attributes = [
+      r.context ? attr('context', r.context) : null,
+      attr('pid', r.pid),
+      r.correlationId ? attr('correlation_id', r.correlationId) : null,
+      r.stack ? attr('exception.stacktrace', r.stack) : null,
+      ...Object.entries(r.meta ?? {}).map(([k, v]) => attr(k, v)),
+    ].filter(Boolean);
+
+    return {
+      // Nanoseconds since epoch, as a string to preserve precision.
+      timeUnixNano: (BigInt(r.timestamp) * 1_000_000n).toString(),
+      severityNumber: OTEL_SEVERITY_NUMBER[r.level] ?? 9,
+      severityText: r.level,
+      body: { stringValue: r.message },
+      attributes,
+      // OTLP/JSON encodes trace/span ids as hex strings.
+      ...(r.trace_id ? { traceId: r.trace_id } : {}),
+      ...(r.span_id ? { spanId: r.span_id } : {}),
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,6 @@ export * from './logger.module';
 export * from './logger.decorator';
 export * from './exporters';
 export * from './context/als';
+export * from './context/trace-context';
+export * from './context/otel-trace-context';
 export * from './context/correlation.middleware';

--- a/src/logger.constants.ts
+++ b/src/logger.constants.ts
@@ -37,3 +37,21 @@ export const DEFAULT_REDACT_KEYS = [
 
 /** Header used by the correlation middleware. */
 export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+/** W3C Trace Context header carrying `version-traceId-spanId-flags`. */
+export const TRACEPARENT_HEADER = 'traceparent';
+
+/**
+ * Maps our log levels to the OpenTelemetry `SeverityNumber` enum used by the
+ * OTLP log data model.
+ * @see https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+ * @internal
+ */
+export const OTEL_SEVERITY_NUMBER: Record<string, number> = {
+  verbose: 1, // TRACE
+  debug: 5, // DEBUG
+  log: 9, // INFO
+  warn: 13, // WARN
+  error: 17, // ERROR
+  fatal: 21, // FATAL
+};

--- a/src/logger.dispatcher.spec.ts
+++ b/src/logger.dispatcher.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { defaultTraceContextProvider } from './context/trace-context';
 import { LogDispatcher } from './logger.dispatcher';
 import type {
   LogExporter,
@@ -24,6 +25,7 @@ const options = (
   redact: [],
   exporters,
   batch: { size: batch?.size ?? 100, intervalMs: batch?.intervalMs ?? 2000 },
+  traceContext: defaultTraceContextProvider,
 });
 
 const collector = (): LogExporter & { records: LogRecord[] } => {

--- a/src/logger.dispatcher.ts
+++ b/src/logger.dispatcher.ts
@@ -38,6 +38,14 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
   }
 
   async onModuleInit(): Promise<void> {
+    try {
+      await this.options.traceContext?.init?.();
+    } catch (err) {
+      this.diag.error(
+        `Trace context provider "${this.options.traceContext?.name}" failed to initialize: ${String(err)}`,
+      );
+    }
+
     await Promise.allSettled(
       this.exporters.map(async (exporter) => {
         try {

--- a/src/logger.interfaces.ts
+++ b/src/logger.interfaces.ts
@@ -26,8 +26,49 @@ export interface LogRecord {
   stack?: string;
   /** Correlation id propagated from the async context, when present. */
   correlationId?: string;
+  /**
+   * W3C/OpenTelemetry trace id (32-char hex) propagated across the request.
+   * Emitted in snake_case to match the OTel/ECS log data model so backends
+   * (Loki, Datadog, Elastic) auto-correlate logs with traces.
+   */
+  trace_id?: string;
+  /** OpenTelemetry span id (16-char hex) of the active span, when present. */
+  span_id?: string;
+  /** OpenTelemetry trace flags (2-char hex, e.g. `01` when sampled). */
+  trace_flags?: string;
   /** Arbitrary structured metadata attached to the entry. */
   meta?: Record<string, unknown>;
+}
+
+/**
+ * The trace correlation data attached to every log entry. Produced by a
+ * {@link TraceContextProvider} and mapped onto the snake_case fields of a
+ * {@link LogRecord}.
+ */
+export interface TraceContext {
+  /** Trace id (32-char hex). */
+  traceId?: string;
+  /** Span id (16-char hex). */
+  spanId?: string;
+  /** Trace flags (2-char hex). */
+  traceFlags?: string;
+  /** Correlation id (non-OTel; survives when no tracing is active). */
+  correlationId?: string;
+}
+
+/**
+ * Pluggable source of trace correlation. The default implementation reads
+ * from an `AsyncLocalStorage` store fed by the W3C `traceparent` header;
+ * swap in {@link OtelTraceContextProvider} to read the active OpenTelemetry
+ * span instead. Custom providers can bridge any tracing system.
+ */
+export interface TraceContextProvider {
+  /** Stable identifier used in diagnostics. */
+  readonly name: string;
+  /** Optional async setup (e.g. importing `@opentelemetry/api`). */
+  init?(): Promise<void> | void;
+  /** Returns the current trace context. MUST be synchronous. */
+  getContext(): TraceContext | undefined;
 }
 
 /**
@@ -80,6 +121,12 @@ export interface LoggerModuleOptions {
   exporters?: LogExporter[];
   /** Batching thresholds for the dispatcher. */
   batch?: BatchOptions;
+  /**
+   * Source of trace correlation stamped onto every record. Defaults to the
+   * zero-dep ALS provider (W3C `traceparent`); pass an
+   * `OtelTraceContextProvider` to read the active OpenTelemetry span.
+   */
+  traceContext?: TraceContextProvider;
 }
 
 /**

--- a/src/logger.module.ts
+++ b/src/logger.module.ts
@@ -1,4 +1,5 @@
 import type { DynamicModule, Provider } from '@nestjs/common';
+import { defaultTraceContextProvider } from './context/trace-context';
 import { LOG_DISPATCHER, LOGGER_OPTIONS } from './logger.constants';
 import { LogDispatcher } from './logger.dispatcher';
 import type {
@@ -25,6 +26,7 @@ const resolveOptions = (
     size: options.batch?.size ?? 100,
     intervalMs: options.batch?.intervalMs ?? 2000,
   },
+  traceContext: options.traceContext ?? defaultTraceContextProvider,
 });
 
 const coreProviders: Provider[] = [

--- a/src/logger.service.spec.ts
+++ b/src/logger.service.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runWithStore } from './context/als';
+import { defaultTraceContextProvider } from './context/trace-context';
 import { LogDispatcher } from './logger.dispatcher';
 import { LoggerService } from './logger.service';
 import type { LogRecord, ResolvedLoggerOptions } from './logger.interfaces';
@@ -11,6 +12,7 @@ const opts: ResolvedLoggerOptions = {
   redact: [],
   exporters: [],
   batch: { size: 100, intervalMs: 2000 },
+  traceContext: defaultTraceContextProvider,
 };
 
 const makeService = () => {
@@ -73,6 +75,28 @@ describe('LoggerService', () => {
 
     expect(captured[0].correlationId).toBe('abc-123');
     expect(captured[0].meta).toMatchObject({ tenant: 'acme' });
+  });
+
+  it('stamps snake_case trace fields and keeps them out of meta', () => {
+    const { service, captured } = makeService();
+
+    runWithStore(
+      {
+        correlationId: 'c1',
+        traceId: 'a'.repeat(32),
+        spanId: 'b'.repeat(16),
+        traceFlags: '01',
+        tenant: 'acme',
+      },
+      () => service.log('traced'),
+    );
+
+    const r = captured[0];
+    expect(r.trace_id).toBe('a'.repeat(32));
+    expect(r.span_id).toBe('b'.repeat(16));
+    expect(r.trace_flags).toBe('01');
+    expect(r.correlationId).toBe('c1');
+    expect(r.meta).toEqual({ tenant: 'acme' }); // trace keys excluded from meta
   });
 
   it('derives "Application" as the fallback context', () => {

--- a/src/logger.service.ts
+++ b/src/logger.service.ts
@@ -7,14 +7,23 @@ import {
   Scope,
 } from '@nestjs/common';
 import { INQUIRER } from '@nestjs/core';
-import { getCorrelationId, getStore } from './context/als';
+import { getStore } from './context/als';
+import { defaultTraceContextProvider } from './context/trace-context';
 import { LOG_DISPATCHER, LOGGER_OPTIONS } from './logger.constants';
 import type { LogDispatcher } from './logger.dispatcher';
 import type {
   LogLevel,
   LogRecord,
   ResolvedLoggerOptions,
+  TraceContextProvider,
 } from './logger.interfaces';
+
+const TRACE_STORE_KEYS = new Set([
+  'correlationId',
+  'traceId',
+  'spanId',
+  'traceFlags',
+]);
 
 /**
  * Drop-in replacement for NestJS' built-in logger.
@@ -29,6 +38,7 @@ import type {
 @Injectable({ scope: Scope.TRANSIENT })
 export class LoggerService extends ConsoleLogger {
   private readonly dispatcher?: LogDispatcher;
+  private readonly trace: TraceContextProvider;
 
   constructor(
     @Optional() @Inject(INQUIRER) parent?: object | string,
@@ -44,6 +54,7 @@ export class LoggerService extends ConsoleLogger {
     });
 
     this.dispatcher = dispatcher;
+    this.trace = options?.traceContext ?? defaultTraceContextProvider;
   }
 
   private static contextFrom(parent?: object | string): string {
@@ -113,12 +124,14 @@ export class LoggerService extends ConsoleLogger {
     const store = getStore();
     if (store) {
       const extra = Object.fromEntries(
-        Object.entries(store).filter(([key]) => key !== 'correlationId'),
+        Object.entries(store).filter(([key]) => !TRACE_STORE_KEYS.has(key)),
       );
       if (Object.keys(extra).length) {
         meta = { ...(meta ?? {}), ...extra };
       }
     }
+
+    const tc = this.trace.getContext();
 
     return {
       level,
@@ -127,7 +140,10 @@ export class LoggerService extends ConsoleLogger {
       timestamp: Date.now(),
       pid: process.pid,
       stack: typeof errorStack === 'string' ? errorStack : undefined,
-      correlationId: getCorrelationId(),
+      correlationId: tc?.correlationId,
+      trace_id: tc?.traceId,
+      span_id: tc?.spanId,
+      trace_flags: tc?.traceFlags,
       meta,
     };
   }

--- a/src/logger.utils.ts
+++ b/src/logger.utils.ts
@@ -1,5 +1,6 @@
+import { randomBytes } from 'node:crypto';
 import { DEFAULT_REDACT_KEYS, LEVEL_RANK } from './logger.constants';
-import type { LogLevel, LogRecord } from './logger.interfaces';
+import type { LogLevel, LogRecord, TraceContext } from './logger.interfaces';
 
 /**
  * Builds the DI token used to inject a context-scoped logger.
@@ -8,6 +9,41 @@ import type { LogLevel, LogRecord } from './logger.interfaces';
  */
 export const getLoggerToken = (context = ''): string =>
   `LoggerService:${context}`;
+
+/** Generates a random W3C/OpenTelemetry trace id (16 bytes → 32 hex chars). */
+export const generateTraceId = (): string => randomBytes(16).toString('hex');
+
+/** Generates a random W3C/OpenTelemetry span id (8 bytes → 16 hex chars). */
+export const generateSpanId = (): string => randomBytes(8).toString('hex');
+
+const TRACEPARENT_RE =
+  /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+/**
+ * Parses a W3C `traceparent` header value into a {@link TraceContext}.
+ * Returns `undefined` for malformed values or the all-zero (invalid) trace id.
+ *
+ * @see https://www.w3.org/TR/trace-context/#traceparent-header
+ */
+export const parseTraceparent = (
+  value: string | undefined,
+): TraceContext | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const match = TRACEPARENT_RE.exec(value.trim());
+  if (!match) {
+    return undefined;
+  }
+
+  const [, , traceId, spanId, traceFlags] = match;
+  if (/^0+$/.test(traceId) || /^0+$/.test(spanId)) {
+    return undefined;
+  }
+
+  return { traceId, spanId, traceFlags };
+};
 
 /**
  * Returns the enabled log levels for a minimum level, honoring NestJS'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     '@aws-sdk/client-dynamodb',
     '@aws-sdk/lib-dynamodb',
     '@aws-sdk/client-cloudwatch-logs',
+    '@opentelemetry/api',
   ],
 });


### PR DESCRIPTION
Every log now carries a trace_id/span_id/trace_flags (snake_case, per the OpenTelemetry/ECS log data model) plus a correlationId, so a single id traverses all logs of a request and backends auto-correlate logs with traces.

- Add a pluggable TraceContextProvider abstraction:
  - AlsTraceContextProvider (default, zero-dep) reads the async store.
  - OtelTraceContextProvider reads the active OpenTelemetry span (@opentelemetry/api as an optional peer dependency), falling back to the async store when no span is active.
- Enhance the middleware to honor the W3C `traceparent` header and generate fresh trace/span ids otherwise; expose a TracingMiddleware alias.
- Add OtlpExporter: ships logs to an OpenTelemetry Collector over OTLP/HTTP (JSON) using global fetch — no OTel SDK required; maps trace_id/span_id onto the OTLP record for log/trace correlation.
- Wire the provider through LoggerService (snake_case mapping, trace keys kept out of meta), the dispatcher (init lifecycle) and the module (default).
- Add utils: generateTraceId/generateSpanId/parseTraceparent, OTLP severity mapping. Tests: 42 passing (trace-context, middleware, OTLP, updated fixtures).
- Docs: README OpenTelemetry section.


Claude-Session: https://claude.ai/code/session_0189XtQZGfiNSc6RJE2TDC3Y