### PR TITLE
feat: dispatcher resilience + HTTP logging interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,41 @@ export class SlackExporter implements LogExporter {
 }
 ```
 
+## HTTP request logging
+
+Register `LoggingInterceptor` to log one line per HTTP request — method, path,
+status code and latency — automatically stamped with the active `trace_id` /
+`correlationId`:
+
+```ts
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { LoggingInterceptor } from '@mpgxc/logx';
+
+@Module({
+  providers: [{ provide: APP_INTERCEPTOR, useClass: LoggingInterceptor }],
+})
+export class AppModule {}
+```
+
+Requests slower than `slowThresholdMs` are logged at `warn`; failures at
+`error` (and re-thrown). Non-HTTP contexts (RPC/WebSocket) pass through
+untouched. Configure via the `LOGGING_OPTIONS` token:
+
+```ts
+{ provide: LOGGING_OPTIONS, useValue: { slowThresholdMs: 500, includeIp: true } }
+```
+
+## Resilience
+
+The dispatcher never lets logging destabilize the app:
+
+- **Bounded buffer** — capped at `maxBufferSize`; on overflow it sheds load per
+  `dropPolicy` (`oldest` by default) instead of growing without limit.
+- **Retry with backoff** — a failing `export` is retried (`retry.attempts`) with
+  exponential backoff before the batch is given up on.
+- **Failure isolation** — one broken exporter never affects the others or the app.
+- **Counters** — `dispatcher.stats` exposes `{ buffered, exported, dropped, failed }`.
+
 ## Configuration reference
 
 ```ts
@@ -230,6 +265,9 @@ LoggerModule.forRoot({
   redact?: string[];    // keys stripped from meta          (default: [])
   exporters?: LogExporter[];                                 // default: []
   batch?: { size?: number; intervalMs?: number };            // default: 100 / 2000ms
+  maxBufferSize?: number;                                     // default: 10000
+  dropPolicy?: 'oldest' | 'newest';                          // default: 'oldest'
+  retry?: { attempts?: number; backoffMs?: number; maxBackoffMs?: number }; // 3 / 200 / 5000
   traceContext?: TraceContextProvider;                       // default: ALS (zero-dep)
 });
 ```

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
+    "rxjs": "^7.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './logger.dispatcher';
 export * from './logger.module';
 export * from './logger.decorator';
 export * from './exporters';
+export * from './interceptors';
 export * from './context/als';
 export * from './context/trace-context';
 export * from './context/otel-trace-context';

--- a/src/interceptors/index.ts
+++ b/src/interceptors/index.ts
@@ -1,0 +1,1 @@
+export * from './logging.interceptor';

--- a/src/interceptors/logging.interceptor.spec.ts
+++ b/src/interceptors/logging.interceptor.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { delay } from 'rxjs/operators';
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { LoggingInterceptor } from './logging.interceptor';
+import type { LoggerService } from '../logger.service';
+import type { LoggingInterceptorOptions } from '../logger.interfaces';
+
+const makeLogger = () => {
+  const calls: { level: string; message: string; meta?: unknown }[] = [];
+  const record = (level: string) => (message: string, meta?: unknown) =>
+    calls.push({ level, message, meta });
+  const logger = {
+    setContext: vi.fn(),
+    log: record('log'),
+    warn: record('warn'),
+    error: record('error'),
+  } as unknown as LoggerService;
+  return { logger, calls };
+};
+
+const httpContext = (
+  req: Record<string, unknown>,
+  res: Record<string, unknown>,
+  type = 'http',
+): ExecutionContext =>
+  ({
+    getType: () => type,
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  }) as unknown as ExecutionContext;
+
+const handler = (obs: unknown): CallHandler =>
+  ({ handle: () => obs }) as unknown as CallHandler;
+
+const build = (opts?: LoggingInterceptorOptions) => {
+  const { logger, calls } = makeLogger();
+  return { interceptor: new LoggingInterceptor(logger, opts), calls, logger };
+};
+
+describe('LoggingInterceptor', () => {
+  it('sets the HTTP context on construction', () => {
+    const { logger } = build();
+    expect(logger.setContext).toHaveBeenCalledWith('HTTP');
+  });
+
+  it('logs method, url, status and duration on success', async () => {
+    const { interceptor, calls } = build();
+    const ctx = httpContext(
+      { method: 'GET', originalUrl: '/users?q=1' },
+      { statusCode: 200 },
+    );
+
+    await lastValueFrom(interceptor.intercept(ctx, handler(of('ok'))));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('log');
+    expect(calls[0].message).toBe('GET /users?q=1');
+    expect(calls[0].meta).toMatchObject({
+      method: 'GET',
+      url: '/users?q=1',
+      statusCode: 200,
+    });
+    expect((calls[0].meta as any).durationMs).toBeTypeOf('number');
+  });
+
+  it('strips the query string when includeQuery is false', async () => {
+    const { interceptor, calls } = build({ includeQuery: false });
+    const ctx = httpContext(
+      { method: 'GET', originalUrl: '/users?q=1' },
+      { statusCode: 200 },
+    );
+
+    await lastValueFrom(interceptor.intercept(ctx, handler(of('ok'))));
+    expect(calls[0].message).toBe('GET /users');
+  });
+
+  it('escalates to warn past the slow threshold', async () => {
+    const { interceptor, calls } = build({ slowThresholdMs: 1 });
+    const ctx = httpContext(
+      { method: 'GET', url: '/slow' },
+      { statusCode: 200 },
+    );
+
+    // Real ~5ms delay reliably exceeds the 1ms threshold.
+    await lastValueFrom(
+      interceptor.intercept(ctx, handler(of('ok').pipe(delay(5)))),
+    );
+    expect(calls[0].level).toBe('warn');
+  });
+
+  it('logs at error level and rethrows on failure', async () => {
+    const { interceptor, calls } = build();
+    const ctx = httpContext({ method: 'POST', url: '/pay' }, {});
+    const err = Object.assign(new Error('boom'), { status: 418 });
+
+    await expect(
+      lastValueFrom(interceptor.intercept(ctx, handler(throwError(() => err)))),
+    ).rejects.toThrow('boom');
+
+    expect(calls[0].level).toBe('error');
+    expect(calls[0].meta).toMatchObject({ statusCode: 418, error: 'boom' });
+  });
+
+  it('passes non-http contexts through without logging', async () => {
+    const { interceptor, calls } = build();
+    const ctx = httpContext({}, {}, 'rpc');
+
+    await lastValueFrom(interceptor.intercept(ctx, handler(of('ok'))));
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -1,0 +1,131 @@
+import {
+  type CallHandler,
+  type ExecutionContext,
+  Inject,
+  Injectable,
+  type NestInterceptor,
+  Optional,
+} from '@nestjs/common';
+import { type Observable, throwError } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { LOGGING_OPTIONS } from '../logger.constants';
+import type { LoggingInterceptorOptions, LogLevel } from '../logger.interfaces';
+import { LoggerService } from '../logger.service';
+
+type ReqLike = {
+  method?: string;
+  originalUrl?: string;
+  url?: string;
+  ip?: string;
+  headers?: Record<string, string | string[] | undefined>;
+};
+type ResLike = { statusCode?: number };
+
+/**
+ * Logs one line per HTTP request with method, path, status code and latency,
+ * automatically stamped with the active `trace_id` / `correlationId` (when
+ * {@link CorrelationMiddleware} is registered).
+ *
+ * Register it globally:
+ * ```ts
+ * import { APP_INTERCEPTOR } from '@nestjs/core';
+ *
+ * @Module({
+ *   providers: [{ provide: APP_INTERCEPTOR, useClass: LoggingInterceptor }],
+ * })
+ * export class AppModule {}
+ * ```
+ *
+ * Non-HTTP execution contexts (RPC, WebSocket) pass through untouched.
+ */
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly options: Required<LoggingInterceptorOptions>;
+
+  constructor(
+    @Inject(LoggerService)
+    private readonly logger: LoggerService,
+    @Optional()
+    @Inject(LOGGING_OPTIONS)
+    options?: LoggingInterceptorOptions,
+  ) {
+    this.logger.setContext('HTTP');
+    this.options = {
+      level: options?.level ?? 'log',
+      slowThresholdMs: options?.slowThresholdMs ?? 0,
+      includeQuery: options?.includeQuery ?? true,
+      includeUserAgent: options?.includeUserAgent ?? false,
+      includeIp: options?.includeIp ?? false,
+    };
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') {
+      return next.handle();
+    }
+
+    const http = context.switchToHttp();
+    const req = http.getRequest<ReqLike>();
+    const res = http.getResponse<ResLike>();
+
+    const method = req.method ?? 'UNKNOWN';
+    const url = this.resolveUrl(req);
+    const start = process.hrtime.bigint();
+
+    const meta = (statusCode: number): Record<string, unknown> => {
+      const data: Record<string, unknown> = {
+        method,
+        url,
+        statusCode,
+        durationMs: this.elapsedMs(start),
+      };
+      if (this.options.includeIp && req.ip) {
+        data.ip = req.ip;
+      }
+      if (this.options.includeUserAgent) {
+        const ua = req.headers?.['user-agent'];
+        if (ua) {
+          data.userAgent = Array.isArray(ua) ? ua[0] : ua;
+        }
+      }
+      return data;
+    };
+
+    return next.handle().pipe(
+      tap(() => {
+        const data = meta(res.statusCode ?? 200);
+        const slow =
+          this.options.slowThresholdMs > 0 &&
+          (data.durationMs as number) > this.options.slowThresholdMs;
+        const level: LogLevel = slow ? 'warn' : this.options.level;
+        // Object arg → structured `meta` on the record (deterministic).
+        this.logger[level](`${method} ${url}`, data);
+      }),
+      catchError((err) => {
+        const status =
+          (err?.status as number) ?? (err?.statusCode as number) ?? 500;
+        const data = meta(status);
+        data.error = err?.message ?? String(err);
+        if (err?.stack) {
+          data.stack = err.stack;
+        }
+        this.logger.error(`${method} ${url}`, data);
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  private resolveUrl(req: ReqLike): string {
+    const raw = req.originalUrl ?? req.url ?? '';
+    if (this.options.includeQuery) {
+      return raw;
+    }
+    const q = raw.indexOf('?');
+    return q === -1 ? raw : raw.slice(0, q);
+  }
+
+  private elapsedMs(start: bigint): number {
+    const ns = Number(process.hrtime.bigint() - start);
+    return Math.round((ns / 1e6) * 100) / 100; // 2 decimal places
+  }
+}

--- a/src/logger.constants.ts
+++ b/src/logger.constants.ts
@@ -11,6 +11,12 @@ export const LOGGER_OPTIONS = Symbol('logx:options');
 export const LOG_DISPATCHER = Symbol('logx:dispatcher');
 
 /**
+ * Optional DI token carrying {@link LoggingInterceptorOptions}.
+ * @internal
+ */
+export const LOGGING_OPTIONS = Symbol('logx:logging-options');
+
+/**
  * Default numeric ordering for cascading level filtering.
  * A record is emitted when its rank is `>=` the configured level's rank.
  * @internal

--- a/src/logger.dispatcher.spec.ts
+++ b/src/logger.dispatcher.spec.ts
@@ -18,6 +18,11 @@ const record = (over: Partial<LogRecord> = {}): LogRecord => ({
 const options = (
   exporters: LogExporter[],
   batch?: Partial<ResolvedLoggerOptions['batch']>,
+  over?: {
+    maxBufferSize?: number;
+    dropPolicy?: ResolvedLoggerOptions['dropPolicy'];
+    retry?: Partial<ResolvedLoggerOptions['retry']>;
+  },
 ): ResolvedLoggerOptions => ({
   level: 'log',
   json: true,
@@ -25,6 +30,13 @@ const options = (
   redact: [],
   exporters,
   batch: { size: batch?.size ?? 100, intervalMs: batch?.intervalMs ?? 2000 },
+  maxBufferSize: over?.maxBufferSize ?? 10_000,
+  dropPolicy: over?.dropPolicy ?? 'oldest',
+  retry: {
+    attempts: over?.retry?.attempts ?? 1,
+    backoffMs: over?.retry?.backoffMs ?? 1,
+    maxBackoffMs: over?.retry?.maxBackoffMs ?? 10,
+  },
   traceContext: defaultTraceContextProvider,
 });
 
@@ -138,5 +150,81 @@ describe('LogDispatcher', () => {
       password: '[REDACTED]',
       user: 'ana',
     });
+  });
+
+  it('drops the oldest record when the buffer is full (dropPolicy: oldest)', () => {
+    const sink = collector();
+    // size huge so batch-size flush never fires; cap at 2.
+    const dispatcher = new LogDispatcher(
+      options([sink], { size: 1000, intervalMs: 0 }, { maxBufferSize: 2 }),
+    );
+
+    dispatcher.dispatch(record({ message: 'a' }));
+    dispatcher.dispatch(record({ message: 'b' }));
+    dispatcher.dispatch(record({ message: 'c' })); // evicts 'a'
+
+    expect(dispatcher.stats.dropped).toBe(1);
+    expect(dispatcher.stats.buffered).toBe(2);
+  });
+
+  it('rejects the incoming record when full (dropPolicy: newest)', () => {
+    const sink = collector();
+    const dispatcher = new LogDispatcher(
+      options(
+        [sink],
+        { size: 1000, intervalMs: 0 },
+        { maxBufferSize: 2, dropPolicy: 'newest' },
+      ),
+    );
+
+    dispatcher.dispatch(record({ message: 'a' }));
+    dispatcher.dispatch(record({ message: 'b' }));
+    dispatcher.dispatch(record({ message: 'c' })); // rejected
+
+    expect(dispatcher.stats.dropped).toBe(1);
+    expect(dispatcher.stats.buffered).toBe(2);
+  });
+
+  it('retries a failing exporter with backoff, then succeeds', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const flaky: LogExporter = {
+      name: 'flaky',
+      export: () => {
+        attempts++;
+        if (attempts < 3) throw new Error('transient');
+      },
+    };
+    const dispatcher = new LogDispatcher(
+      options([flaky], { size: 1 }, { retry: { attempts: 3 } }),
+    );
+
+    dispatcher.dispatch(record());
+    await vi.runAllTimersAsync();
+
+    expect(attempts).toBe(3);
+    expect(dispatcher.stats.failed).toBe(0);
+    expect(dispatcher.stats.exported).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it('gives up after exhausting retries and counts the failure', async () => {
+    vi.useFakeTimers();
+    const broken: LogExporter = {
+      name: 'broken',
+      export: () => {
+        throw new Error('always');
+      },
+    };
+    const dispatcher = new LogDispatcher(
+      options([broken], { size: 1 }, { retry: { attempts: 2 } }),
+    );
+
+    dispatcher.dispatch(record());
+    await vi.runAllTimersAsync();
+
+    expect(dispatcher.stats.failed).toBe(1);
+    expect(dispatcher.stats.exported).toBe(0);
+    vi.useRealTimers();
   });
 });

--- a/src/logger.dispatcher.ts
+++ b/src/logger.dispatcher.ts
@@ -7,16 +7,25 @@ import {
 } from '@nestjs/common';
 import { LOGGER_OPTIONS } from './logger.constants';
 import type {
+  DispatcherStats,
   LogExporter,
   LogRecord,
   ResolvedLoggerOptions,
 } from './logger.interfaces';
 import { redactRecord } from './logger.utils';
 
+const DROP_WARN_INTERVAL_MS = 5000;
+
 /**
  * Central log fan-out. Buffers records and flushes them to every
  * registered exporter in batches, isolating exporter failures so a single
  * broken destination never impacts the application or the other exporters.
+ *
+ * Resilience:
+ * - The buffer is **bounded** (`maxBufferSize`); on overflow it sheds load
+ *   per `dropPolicy` instead of growing without limit.
+ * - Failed exports are **retried** with exponential backoff before the batch
+ *   is given up on.
  *
  * Fire-and-forget: {@link LogDispatcher.dispatch} never blocks the caller
  * and never throws.
@@ -27,6 +36,11 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
   private readonly buffer: LogRecord[] = [];
   private timer: NodeJS.Timeout | null = null;
   private ready = false;
+
+  private exportedCount = 0;
+  private droppedCount = 0;
+  private failedCount = 0;
+  private lastDropWarn = 0;
 
   constructor(
     @Inject(LOGGER_OPTIONS)
@@ -62,8 +76,9 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
-   * Queue a record for export. Applies redaction, buffers it, and triggers
-   * a flush when the batch size is reached. Never throws.
+   * Queue a record for export. Applies redaction, buffers it (shedding load
+   * if the buffer is full), and triggers a flush when the batch size is
+   * reached. Never throws.
    */
   dispatch(record: LogRecord): void {
     if (!this.exporters.length) {
@@ -71,7 +86,18 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
     }
 
     try {
-      this.buffer.push(redactRecord(record, this.options.redact));
+      const redacted = redactRecord(record, this.options.redact);
+
+      if (this.buffer.length >= this.options.maxBufferSize) {
+        if (this.options.dropPolicy === 'newest') {
+          this.onDrop();
+          return; // reject the incoming record
+        }
+        this.buffer.shift(); // drop oldest
+        this.onDrop();
+      }
+
+      this.buffer.push(redacted);
 
       if (this.buffer.length >= this.options.batch.size) {
         void this.flush();
@@ -80,6 +106,18 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
       }
     } catch (err) {
       this.diag.error(`Failed to queue log record: ${String(err)}`);
+    }
+  }
+
+  private onDrop(): void {
+    this.droppedCount++;
+
+    const now = Date.now();
+    if (now - this.lastDropWarn >= DROP_WARN_INTERVAL_MS) {
+      this.lastDropWarn = now;
+      this.diag.warn(
+        `Log buffer full (max ${this.options.maxBufferSize}); shedding "${this.options.dropPolicy}" records. Total dropped: ${this.droppedCount}`,
+      );
     }
   }
 
@@ -98,8 +136,8 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
-   * Drain the buffer to every exporter concurrently. Exporter errors are
-   * captured per-exporter and logged, never propagated.
+   * Drain the buffer to every exporter concurrently, retrying each with
+   * backoff. Exporter errors are captured per-exporter, never propagated.
    */
   async flush(): Promise<void> {
     if (this.timer) {
@@ -113,17 +151,53 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
 
     const batch = this.buffer.splice(0, this.buffer.length);
 
-    await Promise.allSettled(
-      this.exporters.map(async (exporter) => {
-        try {
-          await exporter.export(batch);
-        } catch (err) {
-          this.diag.error(
-            `Exporter "${exporter.name}" failed to export ${batch.length} record(s): ${String(err)}`,
-          );
-        }
-      }),
+    const results = await Promise.allSettled(
+      this.exporters.map((exporter) => this.exportWithRetry(exporter, batch)),
     );
+
+    const delivered = results.some(
+      (r) => r.status === 'fulfilled' && r.value === true,
+    );
+    if (delivered) {
+      this.exportedCount += batch.length;
+    }
+  }
+
+  /**
+   * Attempt an export with exponential backoff. Resolves `true` on success,
+   * `false` once retries are exhausted (never rejects).
+   */
+  private async exportWithRetry(
+    exporter: LogExporter,
+    batch: LogRecord[],
+  ): Promise<boolean> {
+    const { attempts, backoffMs, maxBackoffMs } = this.options.retry;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        await exporter.export(batch);
+        return true;
+      } catch (err) {
+        if (attempt >= attempts) {
+          this.failedCount++;
+          this.diag.error(
+            `Exporter "${exporter.name}" failed to export ${batch.length} record(s) after ${attempts} attempt(s): ${String(err)}`,
+          );
+          return false;
+        }
+        const delay = Math.min(backoffMs * 2 ** (attempt - 1), maxBackoffMs);
+        await this.sleep(delay);
+      }
+    }
+
+    return false;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      const t = setTimeout(resolve, ms);
+      t.unref?.();
+    });
   }
 
   async onApplicationShutdown(): Promise<void> {
@@ -143,6 +217,16 @@ export class LogDispatcher implements OnModuleInit, OnApplicationShutdown {
     );
 
     this.ready = false;
+  }
+
+  /** Runtime counters for observability (buffered / exported / dropped / failed). */
+  get stats(): DispatcherStats {
+    return {
+      buffered: this.buffer.length,
+      exported: this.exportedCount,
+      dropped: this.droppedCount,
+      failed: this.failedCount,
+    };
   }
 
   /** @internal Whether all exporters have been initialized. */

--- a/src/logger.interfaces.ts
+++ b/src/logger.interfaces.ts
@@ -104,6 +104,38 @@ export interface BatchOptions {
 }
 
 /**
+ * What to drop when the buffer is full:
+ * - `oldest`: evict the oldest buffered record (default) — keeps the freshest.
+ * - `newest`: reject the incoming record.
+ */
+export type DropPolicy = 'oldest' | 'newest';
+
+/**
+ * Retry policy applied per-exporter when an `export` call rejects, before the
+ * batch is given up on.
+ */
+export interface RetryOptions {
+  /** Total attempts (including the first). Default: 3. `1` disables retry. */
+  attempts?: number;
+  /** Base backoff in ms; grows exponentially (`backoffMs * 2^n`). Default: 200. */
+  backoffMs?: number;
+  /** Upper bound for a single backoff delay, in ms. Default: 5000. */
+  maxBackoffMs?: number;
+}
+
+/** Runtime counters exposed by the dispatcher for observability. */
+export interface DispatcherStats {
+  /** Records currently sitting in the buffer. */
+  buffered: number;
+  /** Records successfully handed to at least one exporter. */
+  exported: number;
+  /** Records dropped because the buffer was full. */
+  dropped: number;
+  /** Batches given up on after exhausting retries (per exporter). */
+  failed: number;
+}
+
+/**
  * Options accepted by {@link LoggerModule.forRoot}.
  */
 export interface LoggerModuleOptions {
@@ -121,12 +153,35 @@ export interface LoggerModuleOptions {
   exporters?: LogExporter[];
   /** Batching thresholds for the dispatcher. */
   batch?: BatchOptions;
+  /** Max records held in the buffer before dropping. Default: 10000. */
+  maxBufferSize?: number;
+  /** Which record to drop when the buffer is full. Default: `oldest`. */
+  dropPolicy?: DropPolicy;
+  /** Per-exporter retry policy on export failure. */
+  retry?: RetryOptions;
   /**
    * Source of trace correlation stamped onto every record. Defaults to the
    * zero-dep ALS provider (W3C `traceparent`); pass an
    * `OtelTraceContextProvider` to read the active OpenTelemetry span.
    */
   traceContext?: TraceContextProvider;
+}
+
+/**
+ * Options for {@link LoggingInterceptor}, the automatic HTTP request/response
+ * logger.
+ */
+export interface LoggingInterceptorOptions {
+  /** Level for successful requests. Default: `log`. */
+  level?: LogLevel;
+  /** Requests slower than this (ms) are logged at `warn`. Default: disabled. */
+  slowThresholdMs?: number;
+  /** Include the query string in the logged URL. Default: true. */
+  includeQuery?: boolean;
+  /** Include the `user-agent` header. Default: false. */
+  includeUserAgent?: boolean;
+  /** Include the client IP. Default: false. */
+  includeIp?: boolean;
 }
 
 /**
@@ -143,8 +198,9 @@ export interface LoggerModuleAsyncOptions
 
 /** @internal Resolved options with every field populated. */
 export interface ResolvedLoggerOptions
-  extends Required<Omit<LoggerModuleOptions, 'isGlobal' | 'batch'>> {
+  extends Required<Omit<LoggerModuleOptions, 'isGlobal' | 'batch' | 'retry'>> {
   batch: Required<BatchOptions>;
+  retry: Required<RetryOptions>;
 }
 
 /** Convenience alias for a class reference in provider wiring. */

--- a/src/logger.module.ts
+++ b/src/logger.module.ts
@@ -26,6 +26,13 @@ const resolveOptions = (
     size: options.batch?.size ?? 100,
     intervalMs: options.batch?.intervalMs ?? 2000,
   },
+  maxBufferSize: options.maxBufferSize ?? 10_000,
+  dropPolicy: options.dropPolicy ?? 'oldest',
+  retry: {
+    attempts: options.retry?.attempts ?? 3,
+    backoffMs: options.retry?.backoffMs ?? 200,
+    maxBackoffMs: options.retry?.maxBackoffMs ?? 5000,
+  },
   traceContext: options.traceContext ?? defaultTraceContextProvider,
 });
 

--- a/src/logger.service.spec.ts
+++ b/src/logger.service.spec.ts
@@ -12,6 +12,9 @@ const opts: ResolvedLoggerOptions = {
   redact: [],
   exporters: [],
   batch: { size: 100, intervalMs: 2000 },
+  maxBufferSize: 10_000,
+  dropPolicy: 'oldest',
+  retry: { attempts: 3, backoffMs: 200, maxBackoffMs: 5000 },
   traceContext: defaultTraceContextProvider,
 };
 


### PR DESCRIPTION
## Motivação

Duas lacunas de produção: o dispatcher era frágil sob carga/falha, e não havia logging automático de HTTP.

## O que muda

### Robustez do `LogDispatcher`
- **Buffer limitado** em `maxBufferSize` (default 10000) com `dropPolicy` (`oldest` | `newest`) — em vez de crescer sem limite se um exporter travar. Descartes são contados e avisados (warn throttled).
- **Retry com backoff exponencial** (`retry.attempts` / `backoffMs` / `maxBackoffMs`) antes de desistir de um batch (hoje o batch falho era descartado na primeira falha).
- **Contadores** via `dispatcher.stats`: `{ buffered, exported, dropped, failed }`.

### `LoggingInterceptor`
- Loga uma linha por request HTTP (`method`, `url`, `statusCode`, `durationMs`), já carimbada com `trace_id`/`correlationId`.
- Acima de `slowThresholdMs` loga em `warn`; em erro loga (`error`) e re-propaga; contextos não-HTTP (RPC/WS) passam direto.
- Injeta `LoggerService` via `@Inject` explícito (o build com tsup não emite metadata de decorator — mesmo padrão do resto da lib); configurável pelo token `LOGGING_OPTIONS`.
- `rxjs` adicionado como peerDependency.

## Verificação

- `npm ci`, `typecheck`, **52 testes** (era 42), `lint`, `build` — todos verdes.
- **Smoke HTTP real** (app Nest com o interceptor global + `CorrelationMiddleware`): um GET produz 1 log com method/url/status/latência; o `trace_id` propaga do header `traceparent` upstream; o `correlationId` é ecoado no response; e um exporter que falha 2× **faz retry até suceder**. O smoke também pegou (e validou o fix de) um bug real de DI no interceptor.

Vira **2.2.0** na próxima release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189XtQZGfiNSc6RJE2TDC3Y

---
_Generated by [Claude Code](https://claude.ai/code/session_0189XtQZGfiNSc6RJE2TDC3Y)_